### PR TITLE
Fixed capitalisation of dependency, webhelpers => WebHelpers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except IOError:
 requires = [
     'pyramid',
     'WebHelpers',
-    'formencode',
+    'FormEncode',
 ]
 
 setup(name='pyramid_simpleform',


### PR DESCRIPTION
When using 'pip' with any one of the PyPi mirrors it appears that you need to set the correct capitalisation of dependent packages. Only the main mirror supports case insensitive package names. pypi.python.org/simple/webhelpers/ redirects to WebHelpers where as for example f.pypi.python.org/simple/webhelpers/ returns a 404.
