### PR TITLE
Fixed the FormRenderer import in the example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Here is a typical (truncated) example::
 
     from formencode import Schema, validators
     from pyramid_simpleform import Form
+    from pyramid_simpleform.renderers import FormRenderer
 
     class MySchema(Schema):
 


### PR DESCRIPTION
Just a quick fix to the example in the documentation. It was missing an import.
