### PR TITLE
Renderer.checkbox uses the checked keyword param

### DIFF
--- a/pyramid_simpleform/renderers.py
+++ b/pyramid_simpleform/renderers.py
@@ -1,4 +1,3 @@
-
 from webhelpers.html import tags
 from webhelpers.html.builder import HTML
 
@@ -99,7 +98,7 @@ class Renderer(object):
         return tags.checkbox(
             name, 
             value, 
-            self.value(name), 
+            self.value(name, checked), 
             label, 
             self._get_id(id, name), 
             **attrs


### PR DESCRIPTION
Right now, `Renderer.checkbox("name", checked=True)` will ignore the `checked` keyword param and always pass `False` to the `tags.checkbox` method, even if there is no value available for `"name"`. This change allows users to request the renderer to default `checked` to `True`, while still reflecting changes when data is available.

This behavior (allowing a renderer default) matches that of several existing methods, including `textarea`, `text`, and `password`.