### PR TITLE
Include pyramid_mako dependency in test cases

### DIFF
--- a/pyramid_simpleform/tests.py
+++ b/pyramid_simpleform/tests.py
@@ -365,7 +365,8 @@ class TestFormencodeForm(unittest.TestCase):
         settings = {}
 
         settings['mako.directories'] = 'pyramid_simpleform:templates'
-        config = Configurator(settings=settings)
+        config = testing.setUp(settings=settings)
+        config.include('pyramid_mako')
 
 
         request.registry = config.registry
@@ -388,7 +389,8 @@ class TestFormencodeForm(unittest.TestCase):
         settings = {}
 
         settings['mako.directories'] = 'pyramid_simpleform:templates'
-        config = Configurator(settings=settings)
+        config = testing.setUp(settings=settings)
+        config.include('pyramid_mako')
 
 
         request.registry = config.registry

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ except IOError:
 
 requires = [
     'pyramid',
+    'pyramid_mako',
     'WebHelpers',
     'FormEncode',
 ]


### PR DESCRIPTION
Pyramid v1.5 has since deprecated mako dependency in core:
http://docs.pylonsproject.org/projects/pyramid/en/master/whatsnew-1.5.html

Without this change test cases fail on latest versions of Pyramid.