### PR TITLE
Take in account the "checked" parameter when rendering a checkbox

### DIFF
--- a/pyramid_simpleform/renderers.py
+++ b/pyramid_simpleform/renderers.py
@@ -99,7 +99,7 @@ class Renderer(object):
         return tags.checkbox(
             name, 
             value, 
-            self.value(name), 
+            self.value(name, checked), 
             label, 
             self._get_id(id, name), 
             **attrs

--- a/pyramid_simpleform/tests.py
+++ b/pyramid_simpleform/tests.py
@@ -639,9 +639,52 @@ class TestFormencodeFormRenderer(unittest.TestCase):
         request = testing.DummyRequest()
         form = Form(request, SimpleFESchema, defaults={"name" : True})
         renderer = FormRenderer(form)
-        
+
         self.assert_(renderer.checkbox("name") == \
             '<input checked="checked" id="name" name="name" type="checkbox" '
+            'value="1" />')
+
+    def test_checkbox_checked(self):
+        from pyramid_simpleform import Form
+        from pyramid_simpleform.renderers import FormRenderer
+
+        request = testing.DummyRequest()
+        form = Form(request, SimpleFESchema)
+        renderer = FormRenderer(form)
+
+        self.assert_(renderer.checkbox("name") == \
+            '<input id="name" name="name" type="checkbox" '
+            'value="1" />')
+
+        self.assert_(renderer.checkbox("name", checked=True) == \
+            '<input checked="checked" id="name" name="name" type="checkbox" '
+            'value="1" />')
+
+    def test_checkbox_checked_with_default(self):
+        from pyramid_simpleform import Form
+        from pyramid_simpleform.renderers import FormRenderer
+
+        request = testing.DummyRequest()
+        form = Form(request, SimpleFESchema, defaults={"name" : True})
+        renderer = FormRenderer(form)
+
+        self.assert_(renderer.checkbox("name", checked=False) == \
+            '<input checked="checked" id="name" name="name" type="checkbox" '
+            'value="1" />')
+
+        self.assert_(renderer.checkbox("name", checked=True) == \
+            '<input checked="checked" id="name" name="name" type="checkbox" '
+            'value="1" />')
+
+        form = Form(request, SimpleFESchema, defaults={"name" : False})
+        renderer = FormRenderer(form)
+
+        self.assert_(renderer.checkbox("name", checked=False) == \
+            '<input id="name" name="name" type="checkbox" '
+            'value="1" />')
+
+        self.assert_(renderer.checkbox("name", checked=True) == \
+            '<input id="name" name="name" type="checkbox" '
             'value="1" />')
 
     def test_is_error(self):


### PR DESCRIPTION
, using that value in case no default value has been provided for that field.

Otherwise, checked is ignored when trying things like: 

${form.checkbox('some_checkbox', 'This is a checkbox', checked=True)}

in templates, to automatically check the checkbox (based on some parameter available in the template context, for example).